### PR TITLE
Introduce IEvent

### DIFF
--- a/Radar/Clients/Client.cs
+++ b/Radar/Clients/Client.cs
@@ -9,7 +9,7 @@ namespace Radar.Clients
         bool Running { get; }
         string Name { get; }
         void Start();
-        IEnumerable<Event> RecentEvents();
+        IEnumerable<IEvent> RecentEvents();
         void Stop();
     }
 }

--- a/Radar/Clients/DummyClient.cs
+++ b/Radar/Clients/DummyClient.cs
@@ -51,9 +51,9 @@ namespace Radar.Clients
             running = true;
         }
 
-        public IEnumerable<Event> RecentEvents()
+        public IEnumerable<IEvent> RecentEvents()
         {
-            List<Event> events = new List<Event>();
+            List<IEvent> events = new List<IEvent>();
             events.Add(new Event()
 
             {

--- a/Radar/Clients/RepositoryClient.cs
+++ b/Radar/Clients/RepositoryClient.cs
@@ -80,14 +80,14 @@ namespace Radar.Clients
             }
         }
 
-        public IEnumerable<Event> RecentEvents()
+        public IEnumerable<IEvent> RecentEvents()
         {
             lock (runningLock)
             {
                 var eventsRetrieval = (from mr in tracker.MonitoredRepositories
                     select tracker.ProbeMonitoredRepositoriesState(mr)).ToArray();
 
-                IEnumerable<Event>[] events = Task.WhenAll(eventsRetrieval).Result;
+                IEnumerable<IEvent>[] events = Task.WhenAll(eventsRetrieval).Result;
 
                 return events.SelectMany(evs => evs);
             }

--- a/Radar/Event.cs
+++ b/Radar/Event.cs
@@ -2,7 +2,7 @@
 
 namespace Radar
 {
-    public class Event
+    public class Event : IEvent
     {
         public Identity Identity { get; internal set; }
         public DateTime Time { get; internal set; }

--- a/Radar/IEvent.cs
+++ b/Radar/IEvent.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Radar
+{
+    public interface IEvent
+    {
+        Identity Identity { get; }
+        DateTime Time { get; }
+        string Content { get; }
+    }
+}

--- a/Radar/Notifications/ConsoleNotification.cs
+++ b/Radar/Notifications/ConsoleNotification.cs
@@ -26,7 +26,7 @@ namespace Radar.Notifications
             }
         }
 
-        public void Notify(Client client, Event e)
+        public void Notify(Client client, IEvent e)
         {
             TextWriter fh = configuration.Stream == ConsoleNotificationConfiguration.ConsoleStream.Output ?
                 Console.Out : Console.Error;

--- a/Radar/Notifications/MetroNotification.cs
+++ b/Radar/Notifications/MetroNotification.cs
@@ -94,7 +94,7 @@ namespace Radar.Notifications
             return filename;
         }
 
-        public void Notify(Client client, Event e)
+        public void Notify(Client client, IEvent e)
         {
             ToastTemplateType toastTemplate = ToastTemplateType.ToastImageAndText02;
             XmlDocument toastXml = ToastNotificationManager.GetTemplateContent(toastTemplate);

--- a/Radar/Notifications/Notification.cs
+++ b/Radar/Notifications/Notification.cs
@@ -5,7 +5,7 @@ namespace Radar.Notifications
     public interface Notification
     {
         NotificationConfiguration Configuration { get; }
-        void Notify(Client client, Event e);
+        void Notify(Client client, IEvent e);
         void Stop();
     }
 }

--- a/Radar/Radar.cs
+++ b/Radar/Radar.cs
@@ -118,7 +118,7 @@ namespace Radar
             {
                 foreach (Client client in clients)
                 {
-                    IEnumerable<Event> events;
+                    IEnumerable<IEvent> events;
 
                     try
                     {
@@ -131,7 +131,7 @@ namespace Radar
                         continue;
                     }
 
-                    foreach (Event eventData in events)
+                    foreach (IEvent eventData in events)
                     {
                         foreach (Notification notification in notifications)
                         {

--- a/Radar/Radar.csproj
+++ b/Radar/Radar.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Clients\RepositoryClientConfiguration.cs" />
     <Compile Include="Event.cs" />
     <Compile Include="Identity.cs" />
+    <Compile Include="IEvent.cs" />
     <Compile Include="Images\ImageManagerConfiguration.cs" />
     <Compile Include="Tracking\BranchEvent.cs" />
     <Compile Include="Tracking\BranchEventKind.cs" />

--- a/Radar/Tracking/BranchEvent.cs
+++ b/Radar/Tracking/BranchEvent.cs
@@ -136,7 +136,7 @@ namespace Radar.Tracking
                             mr.FriendlyName, ToFriendlyName(CanonicalName), shas.Last());
                         break;
                     case EventKind.BranchResetToAKnownCommit:
-                        ev.Content = string.Format("In remote repository '{0}', branch '{1}' has been reset known commit [{2}]",
+                        ev.Content = string.Format("In remote repository '{0}', branch '{1}' has been reset to a known commit [{2}]",
                             mr.FriendlyName, ToFriendlyName(CanonicalName), shas.Last());
                         break;
                     case EventKind.BranchDeleted:

--- a/Radar/Tracking/BranchEvent.cs
+++ b/Radar/Tracking/BranchEvent.cs
@@ -122,7 +122,7 @@ namespace Radar.Tracking
             ev.Time = sign.Item2;
         }
 
-        public Event BuildEvent(MonitoredRepository mr)
+        public IEvent BuildEvent(MonitoredRepository mr)
         {
             Assert.IsTrue(isFullyAnalyzed, "isFullyAnalyzed");
             Assert.IsTrue(refinedEventKind != EventKind.PendingAnalysis, "refinedEventKind != EventKind.PendingAnalysis");

--- a/Radar/Tracking/RemoteRepositoryTracker.cs
+++ b/Radar/Tracking/RemoteRepositoryTracker.cs
@@ -53,7 +53,7 @@ namespace Radar.Tracking
             get { return monitoredRepositories.ToArray(); }
         }
 
-        public async Task<IEnumerable<Event>> ProbeMonitoredRepositoriesState(MonitoredRepository mr)
+        public async Task<IEnumerable<IEvent>> ProbeMonitoredRepositoriesState(MonitoredRepository mr)
         {
             return await Task.Run(() =>
             {
@@ -163,7 +163,7 @@ namespace Radar.Tracking
             }
         }
 
-        private IEnumerable<Event> Synchronise(MonitoredRepository mr, BranchEvent[] branchEvents)
+        private IEnumerable<IEvent> Synchronise(MonitoredRepository mr, BranchEvent[] branchEvents)
         {
             RemoveReferences(string.Format("refs/radar/{0}/*", mr.FriendlyName));
 


### PR DESCRIPTION
Use an interface rather than a concrete type.

This should allow us to add some more properties to the concrete `Event` type for testability purpose (cf #10)
